### PR TITLE
Grant microphone permission to host content (enables audio mic selector)

### DIFF
--- a/buildResources/electron/electronDevStartup.js
+++ b/buildResources/electron/electronDevStartup.js
@@ -182,6 +182,18 @@ function handleSetCanClose(event, newCanClose) {
     canClose = newCanClose;
 }
 
+// Accorde la permission micro sans prompt OS : l'app est l'hôte de son propre
+// contenu servi sur 127.0.0.1, donc le sélecteur de micro du recorder OBS peut
+// énumérer les périphériques (labels remplis) et enregistrer directement.
+function installAudioCaptureHandlers(ses) {
+    ses.setPermissionRequestHandler((webContents, permission, callback) => {
+        callback(permission === 'media' || permission === 'audioCapture');
+    });
+    ses.setPermissionCheckHandler((webContents, permission) => {
+        return permission === 'media' || permission === 'audioCapture';
+    });
+}
+
 function createWindow() {
 
   console.log('resourcesDir is ' + env.APP_RESOURCES_DIR);
@@ -204,6 +216,8 @@ function createWindow() {
                 sandbox: false, // default is also false
               }
         });
+
+        installAudioCaptureHandlers(win.webContents.session);
 
         win.once('ready-to-show', () => {
             win.maximize();

--- a/buildResources/electron/electronStartup.js
+++ b/buildResources/electron/electronStartup.js
@@ -246,6 +246,18 @@ function handleSetCanClose(event, newCanClose) {
     canClose = newCanClose;
 }
 
+// Accorde la permission micro sans prompt OS : l'app est l'hôte de son propre
+// contenu servi sur 127.0.0.1, donc le sélecteur de micro du recorder OBS peut
+// énumérer les périphériques (labels remplis) et enregistrer directement.
+function installAudioCaptureHandlers(ses) {
+    ses.setPermissionRequestHandler((webContents, permission, callback) => {
+        callback(permission === 'media' || permission === 'audioCapture');
+    });
+    ses.setPermissionCheckHandler((webContents, permission) => {
+        return permission === 'media' || permission === 'audioCapture';
+    });
+}
+
 function createWindow() {
     delay(500).then(() => {
         // console.log('createWindow() - after delay');
@@ -265,6 +277,8 @@ function createWindow() {
                 sandbox: false, // default is also false
               }
         });
+
+        installAudioCaptureHandlers(win.webContents.session);
 
         win.once('ready-to-show', () => {
             win.maximize();


### PR DESCRIPTION
## Overview
 Auto-grants the microphone permission inside the Electron window so the renderer can enumerate audio input devices (with labels) and record directly, without an  OS prompt https://github.com/pankosmia/core-client-workspace/issues/291

## Changes
Both add audio capture handler on the main window, registering a handlers that allow `media` and `audioCapture`.

Required by https://github.com/pankosmia/core-client-workspace/pull/292