### PR TITLE
Nightly build trigger

### DIFF
--- a/.github/workflows/nightlyAllOfDev.yml
+++ b/.github/workflows/nightlyAllOfDev.yml
@@ -1,0 +1,24 @@
+name: Nightly all-of-dev Build Trigger
+
+on:
+  schedule:
+    - cron: '0 4 * * *' # runs daily at 04:00 UTC
+  workflow_dispatch: # optional: allow manual run too
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger buildMaster.yml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run buildMaster.yml \
+            --ref main \
+            -f branches='all of dev' \
+            -f os='all' \
+            -f log_level='critical'

--- a/.github/workflows/nightlyAllOfDev.yml
+++ b/.github/workflows/nightlyAllOfDev.yml
@@ -21,4 +21,4 @@ jobs:
             --ref main \
             -f branches='all of dev' \
             -f os='all' \
-            -f log_level='critical'
+            -f log_level='debug'


### PR DESCRIPTION
### This script is a nightly build trigger for "All of Dev".
- It is currently set to all OSes, though we can change that if targeting just one OS at first is preferred.
- The cron job is currently set for 04:00 UTC
- It currently has a "manual dispatch" option included, which we can remove if we prefer making any such manual requests only via `Master Build` workflow set to the following:
  - Use workflow from `branch: Main` (default)
  - Branches: `all of dev`
  - OS: `all` (default)
  - Log level: ~~`critical` (default)~~ `debug`
  
### Testing
- It is possible to test only the manual dispatch part from where it is, though doing that involves:
  -  Installing GitHub CLI
      - cd /path/to/your/repo
      - `gh auth login`
      - `gh workflow run nightlyAllOfDev.yml --ref run/nightly_build_trigger
- However, as that would not test the cron job we may want to consider folding it in and reviewing on main.
  - That would also allow for the manual dispatch to be triggered through the Actions tab UI, including on other branches as well if follow-up PR's are needed or wanted.

### Can we work with the build dates already displayed in Github Actions? e.g.:
> <img width="151" height="69" alt="image" src="https://github.com/user-attachments/assets/60d97857-5463-474c-9cb2-63f64149fca4" />
- This PR relies on tuning into the build dates already displayed in Github Actions
- If we need a different approach, then among the things to consider are:
  - The build datetime will vary by build unless we go with when the job was requested. But the info in the github actions interface (screenshot above) shows when the entire workflow request finished, so the two won't line up, which may introduce some confusion.
  - Filename names would get longer (which of course does still work), e.g.:
      - `<full-app-name>-<full-version-entry>-<os>-<arch>-<yyyy>-<mm>-<dd>-<hh>-<mm>-<ss>-<z>.<ext>`
  - The date will be different across time zones, which time and time zone would clarify
  - If date time is added to the filename, then we'd need to decide if that is a one-off just for nightly Pithekos builds, or would that become the new pattern all around?
