### PR TITLE
give gh the repository explicitly

### DIFF
--- a/.github/workflows/nightlyAllOfDev.yml
+++ b/.github/workflows/nightlyAllOfDev.yml
@@ -18,6 +18,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run buildMaster.yml \
+            --repo ${{ github.repository }} \
             --ref main \
             -f branches='all of dev' \
             -f os='all' \


### PR DESCRIPTION
This script uses gh command line, which needs to be told explicitly what repo contains the script being triggered.

This PR fixes this error -- `failed to run git: fatal: not a git repository (or any of the parent directories): .git` as demonstrated by [this manual dispatch](https://github.com/pankosmia/desktop-app-pithekos/actions/runs/29343226018) successfully run on this PR's branch. It is what started [this run on main](https://github.com/pankosmia/desktop-app-pithekos/actions/runs/29343235411).