### PR TITLE
3am UTC and remove manual option

### DIFF
--- a/.github/workflows/nightlyAllOfDev.yml
+++ b/.github/workflows/nightlyAllOfDev.yml
@@ -2,8 +2,7 @@ name: Nightly all-of-dev Build Trigger
 
 on:
   schedule:
-    - cron: '0 4 * * *' # runs daily at 04:00 UTC
-  workflow_dispatch: # optional: allow manual run too
+    - cron: '0 3 * * *' # runs daily at 03:00 UTC
 
 permissions:
   actions: write


### PR DESCRIPTION
This PR handles:
- Setting cron to 03:00 UTC
- Removing the manual dispatch option
  - e.g., So a run of this workflow **_cannot_** also be requested manually at any time.
  - e.g., So the only way this workflow is triggered if via cron.