### PR TITLE
Add version suffix "nightly" to nightly runs

### DIFF
--- a/.github/workflows/nightlyAllOfDev.yml
+++ b/.github/workflows/nightlyAllOfDev.yml
@@ -23,5 +23,5 @@ jobs:
             -f branches='all of dev' \
             -f os='all' \
             -f log_level='debug' \
-            -f nightly=true
+            -f artifact_suffix='nightly'
 

--- a/.github/workflows/nightlyAllOfDev.yml
+++ b/.github/workflows/nightlyAllOfDev.yml
@@ -22,4 +22,6 @@ jobs:
             --ref main \
             -f branches='all of dev' \
             -f os='all' \
-            -f log_level='debug'
+            -f log_level='debug' \
+            -f nightly=true
+


### PR DESCRIPTION
This sets up "nightly" as the version suffix for all builds started by this cron job.